### PR TITLE
Fix SIMD scatter kernel: use hybrid shared memory + SIMD approach

### DIFF
--- a/src/gpu_radix_sort.rs
+++ b/src/gpu_radix_sort.rs
@@ -351,15 +351,13 @@ mod metal_impl {
                         encoder.set_buffer(3, Some(&array_size_buffer), 0);
                         encoder.set_buffer(4, Some(&shift_buffer), 0);
 
-                        // Threadgroup memory for SIMD scatter kernel:
+                        // Threadgroup memory for SIMD scatter kernel (same as basic kernel):
                         // - local_offsets: RADIX_SIZE = 256 uints
-                        // - simd_digit_counts: RADIX_SIZE * 8 = 2048 uints (8 SIMD groups)
+                        // - shared_digits: THREADGROUP_SIZE = 256 uints
                         // - digit_counts: RADIX_SIZE = 256 uints
-                        let num_simd_groups = 8;
-                        let simd_counts_mem =
-                            (RADIX_SIZE * num_simd_groups * mem::size_of::<u32>()) as u64;
+                        let threadgroup_mem = (THREADGROUP_SIZE * mem::size_of::<u32>()) as u64;
                         encoder.set_threadgroup_memory_length(0, histogram_tg_mem);
-                        encoder.set_threadgroup_memory_length(1, simd_counts_mem);
+                        encoder.set_threadgroup_memory_length(1, threadgroup_mem);
                         encoder.set_threadgroup_memory_length(2, histogram_tg_mem);
                     } else {
                         encoder.set_compute_pipeline_state(&self.scatter_pipeline);


### PR DESCRIPTION
## Summary

Fixes #17 - GPU radix sort (SIMD) verification failure

### Root Cause

Previous fix attempts used a **pure SIMD approach** with `simd_digit_counts` array for cross-SIMD-group communication. This had subtle bugs:

1. Non-uniform loop bounds initially (`lane < simd_lane`)
2. Even with uniform bounds, the cross-SIMD-group aggregation was error-prone
3. Complex state management across SIMD groups

### The Fix: Hybrid Approach

This fix adopts a **hybrid approach** that combines the best of both worlds:

1. **Shared memory for cross-SIMD-group communication** (like the working basic kernel)
   - Store digits in `shared_digits` array
   - Read from shared memory for counts from earlier SIMD groups
   - Reliable and proven to work

2. **SIMD shuffle for within-SIMD-group optimization**
   - Use `simd_shuffle` with uniform loop bounds (`lane < simd_size`)
   - All threads execute simd_shuffle together (uniform control flow)
   - Conditional counting logic inside the loop

```metal
// Part A: Count from EARLIER SIMD groups (read from shared memory)
if (valid) {
    uint simd_group_start = simd_group_id * simd_size;
    for (uint i = 0; i < simd_group_start; i++) {
        if (shared_digits[i] == digit) {
            rank++;
        }
    }
}

// Part B: Count within our SIMD group (use simd_shuffle)
for (uint lane = 0; lane < simd_size; lane++) {
    uint other_digit = simd_shuffle(digit, lane);  // ALL threads call this
    if (valid && lane < simd_lane && other_digit == digit) {
        rank++;
    }
}
```

### Changes

- `shaders/radix_sort.metal`: Rewrote `radix_scatter_simd` kernel to use hybrid approach
- `src/gpu_radix_sort.rs`: Updated threadgroup memory allocation to match basic kernel
- `docs/case-studies/issue-17/analysis.md`: Updated with detailed root cause analysis

### Why This Should Work

The basic scatter kernel works correctly using shared memory for all rank computation. This fix:
- Uses the **same shared memory pattern** for cross-SIMD-group communication
- Adds SIMD shuffle as an **optimization** for within-group computation (not replacement)
- Maintains **uniform control flow** for simd_shuffle calls

## Test plan

- [x] CI passes (cargo check, cargo test, cargo clippy)
- [ ] Run on macOS with Metal GPU: `cargo run --release -- 2684354`
- [ ] Verify "GPU radix sort (SIMD) verified: OK" appears in output
- [ ] Test with various array sizes (1K, 1M, 10M elements)

## References

- [Apple Developer Forums - simdgroup issues](https://developer.apple.com/forums/thread/703337)
- [Apple G13 GPU Architecture Reference](https://dougallj.github.io/applegpu/docs.html)
- [GPUSorting by b0nes164](https://github.com/b0nes164/GPUSorting)
- [ShoYamanishi/AppleNumericalComputing](https://github.com/ShoYamanishi/AppleNumericalComputing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)